### PR TITLE
Added 3 missing param to Airtime purchase endpoint

### DIFF
--- a/src/PagaBusiness.js
+++ b/src/PagaBusiness.js
@@ -247,7 +247,7 @@ class PagaBusiness extends UtilFunction {
      * @param   {number}    amount                      The amount of airtime to purchase.
      * @param   {number}    currency                    The currency of the operation, if being executed in a foreign currency.
      * @param   {string}    destinationPhoneNumber      The phone number for which airtime is being purchased. If null, and ­­­­Principal is specified, then the airtime will be purchased for the phone number of the purchaserPrincipal. Must be provided if the purchaserPrincipal is null.
-     * @param   {Boolean}   isDataBundle                Default is False but signify as false to purchase data
+     * @param   {Boolean}   isDataBundle                Default is False but signify as True to purchase data
      * @param   {string}    mobileOperatorServiceId     For Data purchase parse the value of mobileOperatorServiceId to indicate the preferred data package
      * @param   {string}    mobileOperatorPublicId      Parse the mobile operator public ID - not compulsory 
      * @param   {string}    purchaserPrincipal          The authentication principal for the user purchasing airtime if the airtime is being purchased on behalf of a user. If null, the airtime will be processed from the 3rd parties own account.

--- a/src/PagaBusiness.js
+++ b/src/PagaBusiness.js
@@ -247,6 +247,9 @@ class PagaBusiness extends UtilFunction {
      * @param   {number}    amount                      The amount of airtime to purchase.
      * @param   {number}    currency                    The currency of the operation, if being executed in a foreign currency.
      * @param   {string}    destinationPhoneNumber      The phone number for which airtime is being purchased. If null, and ­­­­Principal is specified, then the airtime will be purchased for the phone number of the purchaserPrincipal. Must be provided if the purchaserPrincipal is null.
+     * @param   {Boolean}   isDataBundle                Default is False but signify as false to purchase data
+     * @param   {string}    mobileOperatorServiceId     For Data purchase parse the value of mobileOperatorServiceId to indicate the preferred data package
+     * @param   {string}    mobileOperatorPublicId      Parse the mobile operator public ID - not compulsory 
      * @param   {string}    purchaserPrincipal          The authentication principal for the user purchasing airtime if the airtime is being purchased on behalf of a user. If null, the airtime will be processed from the 3rd parties own account.
      * @param   {string}    purchaserCredentials        The authentication credentials for the user purchasing the airtime if the airtime is being purchased on behalf of a user.
      * @param   {string}    sourceOfFunds               The name of a source account for funds. If null, the source purchaser's Paga account will be used as the funding source.
@@ -268,6 +271,9 @@ class PagaBusiness extends UtilFunction {
         amount,
         currency,
         destinationPhoneNumber,
+        isDataBundle,
+        mobileOperatorServiceId,
+        mobileOperatorPublicId,
         purchaserPrincipal,
         purchaserCredentials,
         sourceOfFunds,
@@ -279,6 +285,9 @@ class PagaBusiness extends UtilFunction {
                 amount,
                 currency,
                 destinationPhoneNumber,
+                isDataBundle,
+                mobileOperatorServiceId,
+                mobileOperatorPublicId,
                 purchaserPrincipal,
                 purchaserCredentials,
                 sourceOfFunds,


### PR DESCRIPTION
Some updates to `AirtimePurchase` endpoint that was not previously captured.         
Added `isDataBundle `param to allows user purchase data, `mobileOperatorServiceId` to allow user specify a specific data service and `mobileOperatorPublicId` to select a specific mobile operator